### PR TITLE
Fix ReactDOM root rendering syntax

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import ReactDom from 'react-dom/client';
+import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App.jsx';
 
-ReactDom.createRoot(document.getElementById('root')).render(
+ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
       <BrowserRouter>
           <App />
       </BrowserRouter>
-  </React.StrictMode>,
+  </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- fix naming of `ReactDOM` import
- remove unnecessary trailing comma in `render` call

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847d7b7f94c83259f50add8b7bbe63d